### PR TITLE
Add gateway service for browser control

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,3 +375,4 @@ Additionally, if you are using any of the particular policy architecture, pretra
   year={2024}
 }
 ```
+\n## Gateway service\n\nSee [examples/gateway_service.md](examples/gateway_service.md) for details on launching LeRobot as a remote server.

--- a/examples/gateway_service.md
+++ b/examples/gateway_service.md
@@ -1,0 +1,47 @@
+# Gateway Service
+
+This document describes the backend service that exposes LeRobot training and inference through a simple HTTP API and optional WebSocket relay. The gateway is meant to be deployed on a host machine with GPU resources while browser clients control local robots via Web Serial and WebRTC.
+
+## REST API
+
+### `POST /train`
+Start a training session. Example payload:
+```json
+{
+  "policy": "act",
+  "env": "so100_real",
+  "dataset_repo_id": "<your_dataset_id>",
+  "extra_args": ["--steps=1000"]
+}
+```
+The response contains a `session_id` that can be queried for status.
+
+### `POST /inference`
+Launch an inference process using a pretrained model.
+Payload example:
+```json
+{
+  "model_path": "path/to/model",
+  "extra_args": ["--device=cuda"]
+}
+```
+
+### `GET /session/<session_id>`
+Returns the status (`running`, `finished`, or `unknown`).
+
+### `DELETE /session/<session_id>`
+Terminates a running process.
+
+## WebSocket Relay
+
+Calling :func:`lerobot.gateway.run_websocket_server` starts a lightweight relay used for streaming sensor data and control commands between the browser and the LeRobot process. The implementation relies on the optional `websockets` package.
+
+## Deployment
+
+Run the gateway using:
+```bash
+python lerobot/scripts/run_gateway.py
+```
+This launches the REST API on port `8000` and the WebSocket relay on port `8765`.
+
+Browser clients can interact with these endpoints to orchestrate training or inference runs and exchange real‑time data with the robot hardware.

--- a/lerobot/gateway/__init__.py
+++ b/lerobot/gateway/__init__.py
@@ -1,0 +1,4 @@
+"""Gateway service for remote training and inference."""
+from .service import GatewayService, create_app, run_websocket_server
+
+__all__ = ["GatewayService", "create_app", "run_websocket_server"]

--- a/lerobot/scripts/run_gateway.py
+++ b/lerobot/scripts/run_gateway.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+"""Launch the gateway service."""
+
+from lerobot.gateway import create_app, run_websocket_server
+import threading
+
+
+def main() -> None:
+    ws_thread = threading.Thread(target=run_websocket_server, daemon=True)
+    ws_thread.start()
+    app = create_app()
+    app.run(host="0.0.0.0", port=8000)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add new gateway module with REST and WebSocket support
- provide script to launch gateway service
- document API usage and deployment instructions
- reference gateway docs from README

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'serial')*

------
https://chatgpt.com/codex/tasks/task_b_683d00a32cb8832a8189109047a4e6ca