### PR TITLE
Enable gateway bus CLI overrides

### DIFF
--- a/lerobot/common/robot_devices/control_configs.py
+++ b/lerobot/common/robot_devices/control_configs.py
@@ -5,7 +5,11 @@ from pathlib import Path
 import draccus
 
 from lerobot.common.robot_devices.robots.configs import RobotConfig
-from lerobot.common.utils.utils import auto_select_torch_device, is_amp_available, is_torch_device_available
+from lerobot.common.utils.utils import (
+    auto_select_torch_device,
+    is_amp_available,
+    is_torch_device_available,
+)
 from lerobot.configs import parser
 from lerobot.configs.policies import PreTrainedConfig
 from lerobot.configs.train import TrainPipelineConfig
@@ -92,7 +96,9 @@ class RecordControlConfig(ControlConfig):
         policy_path = parser.get_path_arg("control.policy")
         if policy_path:
             cli_overrides = parser.get_cli_overrides("control.policy")
-            self.policy = PreTrainedConfig.from_pretrained(policy_path, cli_overrides=cli_overrides)
+            self.policy = PreTrainedConfig.from_pretrained(
+                policy_path, cli_overrides=cli_overrides
+            )
             self.policy.pretrained_path = policy_path
 
             # When no device or use_amp are given, use the one from training config.
@@ -106,7 +112,9 @@ class RecordControlConfig(ControlConfig):
             # Automatically switch to available device if necessary
             if not is_torch_device_available(self.device):
                 auto_device = auto_select_torch_device()
-                logging.warning(f"Device '{self.device}' is not available. Switching to '{auto_device}'.")
+                logging.warning(
+                    f"Device '{self.device}' is not available. Switching to '{auto_device}'."
+                )
                 self.device = auto_device
 
             # Automatically deactivate AMP if necessary
@@ -144,3 +152,10 @@ class ControlPipelineConfig:
     def __get_path_fields__(cls) -> list[str]:
         """This enables the parser to load config from the policy using `--policy.path=local/dir`"""
         return ["control.policy"]
+
+    @classmethod
+    def __get_dict_fields__(cls) -> list[str]:
+        return ["robot.leader_arms", "robot.follower_arms"]
+
+    def __post_init__(self) -> None:
+        parser.apply_gateway_overrides(self.robot)

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -1,60 +1,88 @@
 import threading
+from pathlib import Path
 from lerobot.gateway.service import GatewayService
 from lerobot.common.robot_devices.motors.gateway import GatewayMotorsBus
 from lerobot.common.robot_devices.motors.configs import GatewayMotorsBusConfig
 from tests.utils import FEETECH_MOTORS
 
+
 class DummyThread:
     def __init__(self, target, args=(), daemon=None):
         self.target = target
         self.args = args
+
     def start(self):
         pass
 
+
 def test_start_inference_builds_command(monkeypatch):
     calls = {}
+
     def fake_spawn(self, cmd):
-        calls['cmd'] = cmd
+        calls["cmd"] = cmd
+
         class P:
             stdout = []
             returncode = 0
+
             def poll(self):
                 return None
+
             def wait(self, timeout=None):
                 return 0
+
         return P()
 
-    monkeypatch.setattr(GatewayService, '_spawn', fake_spawn)
-    monkeypatch.setattr(GatewayService, '_stream_output', lambda *a, **k: None)
-    monkeypatch.setattr(threading, 'Thread', DummyThread)
+    monkeypatch.setattr(GatewayService, "_spawn", fake_spawn)
+    monkeypatch.setattr(GatewayService, "_stream_output", lambda *a, **k: None)
+    monkeypatch.setattr(threading, "Thread", DummyThread)
 
     service = GatewayService()
     cfg = {
-        'policy_path': 'model',
-        'repo_id': 'user/eval',
-        'single_task': 'task',
-        'robot_type': 'so100',
-        'ws_url': 'ws://client'
+        "policy_path": "model",
+        "repo_id": "user/eval",
+        "single_task": "task",
+        "robot_type": "so100",
+        "ws_url": "ws://client",
     }
     service.start_inference(cfg)
-    cmd = calls['cmd']
-    assert 'control_robot.py' in cmd[1]
-    assert '--control.policy.path=model' in cmd
-    assert '--control.repo_id=user/eval' in cmd
-    assert '--robot.type=so100' in cmd
-    assert '--robot.leader_arms.main.type=gateway' in cmd
-    assert '--robot.leader_arms.main.url=ws://client' in cmd
+    cmd = calls["cmd"]
+    assert "control_robot.py" in cmd[1]
+    assert "--control.policy.path=model" in cmd
+    assert "--control.repo_id=user/eval" in cmd
+    assert "--robot.type=so100" in cmd
+    assert "--robot.leader_arms.main.type=gateway" in cmd
+    assert "--robot.leader_arms.main.url=ws://client" in cmd
+
+
+def test_control_robot_parses_gateway_cli(tmp_path):
+    import subprocess, sys
+
+    script = Path("lerobot/scripts/control_robot.py").resolve()
+    cmd = [
+        sys.executable,
+        str(script),
+        "--robot.type=so100",
+        "--robot.mock=true",
+        "--robot.leader_arms.main.type=gateway",
+        "--robot.leader_arms.main.url=ws://localhost:8765",
+        "--robot.follower_arms.main.type=gateway",
+        "--robot.follower_arms.main.url=ws://localhost:8765",
+        "--control.type=teleoperate",
+        "--control.teleop_time_s=0",
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
 
 
 def test_gateway_bus_mock_mode():
-    cfg = GatewayMotorsBusConfig(url='ws://localhost', motors=FEETECH_MOTORS, mock=True)
+    cfg = GatewayMotorsBusConfig(url="ws://localhost", motors=FEETECH_MOTORS, mock=True)
     bus = GatewayMotorsBus(cfg)
     assert not bus.is_connected
     bus.connect()
     assert bus.is_connected
-    bus.write('Torque_Enable', 1)
-    obs = bus.read('Present_Position')
+    bus.write("Torque_Enable", 1)
+    obs = bus.read("Present_Position")
     assert len(obs) == len(FEETECH_MOTORS)
     bus.disconnect()
     assert not bus.is_connected
-


### PR DESCRIPTION
## Summary
- allow passing nested bus config on CLI for gateway mode
- update ControlPipelineConfig to accept leader/follower arms overrides
- test CLI parsing with gateway arguments

## Testing
- `pytest -k gateway -q` *(fails: module 'torch' has no attribute 'Tensor')*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_gateway.py::test_control_robot_parses_gateway_cli -q` *(fails: module 'torch' has no attribute 'Tensor')*

------
https://chatgpt.com/codex/tasks/task_b_683e569d9f9c832aba703739d8b8aecd