### PR TITLE
Auto-fill session ID after inference

### DIFF
--- a/lerobot/gateway/templates/index.html
+++ b/lerobot/gateway/templates/index.html
@@ -87,7 +87,13 @@
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify(data)
       });
-      document.getElementById('inferenceResult').textContent = await res.text();
+      const result = await res.json();
+      document.getElementById('inferenceResult').textContent = JSON.stringify(result, null, 2);
+      if (result.session_id) {
+        document.querySelector('#stopForm input[name="session_id"]').value = result.session_id;
+        document.querySelector('#statusForm input[name="session_id"]').value = result.session_id;
+        document.querySelector('#logsForm input[name="session_id"]').value = result.session_id;
+      }
     };
 
     document.getElementById('stopForm').onsubmit = async function(e) {


### PR DESCRIPTION
## Summary
- auto-update stop/status/logs forms with session ID returned from starting inference

## Testing
- `pytest -q` *(fails: AttributeError: module 'torch' has no attribute 'Tensor')*

------
https://chatgpt.com/codex/tasks/task_b_683e62003764832aab1668f01411d9a1