### PR TITLE
Fix websocket relay startup

### DIFF
--- a/lerobot/gateway/service.py
+++ b/lerobot/gateway/service.py
@@ -191,4 +191,8 @@ def run_websocket_server(host: str = "0.0.0.0", port: int = 8765) -> None:
         except websockets.ConnectionClosed:  # pragma: no cover - network required
             pass
 
-    asyncio.run(websockets.serve(relay, host, port))
+    async def serve() -> None:
+        async with websockets.serve(relay, host, port):
+            await asyncio.Future()  # run forever
+
+    asyncio.run(serve())


### PR DESCRIPTION
## Summary
- keep websocket running within an async loop

## Testing
- `pytest -q` *(fails: AttributeError: module 'torch' has no attribute 'Tensor')*

------
https://chatgpt.com/codex/tasks/task_b_683e6bf4dd70832a963091ac383863bc