### PR TITLE
Fix pseudo TTY support for Feetech bus

### DIFF
--- a/lerobot/common/robot_devices/motors/feetech.py
+++ b/lerobot/common/robot_devices/motors/feetech.py
@@ -306,6 +306,15 @@ class FeetechMotorsBus:
         self.port_handler = scs.PortHandler(self.port)
         self.packet_handler = scs.PacketHandler(PROTOCOL_VERSION)
 
+        # Serial pseudo terminals like /dev/ttys* may not support setting a
+        # custom baudrate such as 1Mbit.  When operating through a gateway, the
+        # actual baudrate of the physical port is handled on the client side and
+        # the local pseudo-terminal is only used as a byte pipe.  To avoid
+        # ioctl errors when opening such ports, fall back to a standard baudrate
+        # that is widely supported.
+        if str(self.port).startswith("/dev/ttys"):
+            self.port_handler.baudrate = 115_200
+
         try:
             if not self.port_handler.openPort():
                 raise OSError(f"Failed to open port '{self.port}'.")

--- a/lerobot/common/robot_devices/motors/gateway.py
+++ b/lerobot/common/robot_devices/motors/gateway.py
@@ -142,12 +142,6 @@ class GatewayMotorsBus:
             )
             self._backend = FeetechMotorsBus(cfg)
 
-        # Patch connect to skip port opening for pty
-        if str(self.port).startswith("/dev/ttys"):
-            def noop_connect():
-                self._backend.is_connected = True
-            self._backend.connect = noop_connect
-
         self._backend.connect()
         self.is_connected = True
 


### PR DESCRIPTION
## Summary
- configure Feetech motor bus to use a standard baud rate when running on a `/dev/ttys*` pseudo terminal
- remove bypass in GatewayMotorsBus so the backend connects normally

## Testing
- `python -m pytest -sv` *(fails: AttributeError: module 'torch' has no attribute 'Tensor')*

------
https://chatgpt.com/codex/tasks/task_b_683f3e3e9f20832ab47da2f06dae3853