### PR TITLE
Add camera gateway support

### DIFF
--- a/examples/gateway_service.md
+++ b/examples/gateway_service.md
@@ -33,11 +33,13 @@ Payload example:
 The optional `ws_url` tells the service how to reach the browser's Web Serial
 bridge. When provided, motor commands are forwarded over this WebSocket
 connection instead of relying on local USB ports configured in the robot YAML.
+Camera frames can also be relayed for visualization or recording.
 
-The WebSocket relay transmits raw binary serial data. Bytes written by the
-robot SDK are sent as binary messages and the browser must forward the payload
-to its Web Serial port. Likewise, any bytes coming from the serial port are
-sent back to the server as binary WebSocket frames.
+The WebSocket relay transmits raw binary serial data for motors and JPEG
+images for cameras. Bytes written by the robot SDK are sent as binary
+messages and the browser must forward the payload to its Web Serial port.
+Likewise, any bytes coming from the serial port are sent back to the server
+as binary WebSocket frames.
 
 ### `GET /session/<session_id>`
 Returns the status (`running`, `finished`, or `unknown`).

--- a/lerobot/__init__.py
+++ b/lerobot/__init__.py
@@ -188,6 +188,7 @@ available_robots = [
 available_cameras = [
     "opencv",
     "intelrealsense",
+    "gateway",
 ]
 
 # lists all available motors from `lerobot/common/robot_devices/motors`

--- a/lerobot/common/robot_devices/cameras/configs.py
+++ b/lerobot/common/robot_devices/cameras/configs.py
@@ -98,3 +98,14 @@ class IntelRealSenseCameraConfig(CameraConfig):
 
         if self.rotation not in [-90, None, 90, 180]:
             raise ValueError(f"`rotation` must be in [-90, None, 90, 180] (got {self.rotation})")
+@CameraConfig.register_subclass("gateway")
+@dataclass
+class GatewayCameraConfig(CameraConfig):
+    """Configuration for cameras streaming via a WebSocket gateway."""
+
+    url: str
+    width: int | None = None
+    height: int | None = None
+    fps: int | None = None
+    mock: bool = False
+

--- a/lerobot/common/robot_devices/cameras/gateway.py
+++ b/lerobot/common/robot_devices/cameras/gateway.py
@@ -1,0 +1,103 @@
+"""Camera streaming over a WebSocket connection."""
+
+import asyncio
+import threading
+import time
+from typing import Any
+
+import numpy as np
+
+from lerobot.common.robot_devices.cameras.configs import GatewayCameraConfig
+from lerobot.common.robot_devices.utils import (
+    RobotDeviceAlreadyConnectedError,
+    RobotDeviceNotConnectedError,
+)
+from lerobot.common.utils.utils import capture_timestamp_utc
+
+
+class GatewayCamera:
+    """Receive JPEG frames over a WebSocket."""
+
+    def __init__(self, config: GatewayCameraConfig) -> None:
+        self.url = config.url
+        self.width = config.width or 640
+        self.height = config.height or 480
+        self.fps = config.fps
+        self.mock = config.mock
+
+        self._ws = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
+        self._frame: np.ndarray | None = None
+        self._last_time = 0.0
+
+        self.is_connected = False
+        self.logs: dict[str, Any] = {}
+
+    # ------------------------------------------------------------------
+    def _run(self) -> None:
+        import cv2
+        import websockets  # type: ignore
+
+        async def receive() -> None:
+            async with websockets.connect(self.url) as ws:
+                self._ws = ws
+                async for message in ws:
+                    arr = np.frombuffer(message, dtype=np.uint8)
+                    img = cv2.imdecode(arr, cv2.IMREAD_COLOR)
+                    if img is not None:
+                        now = time.perf_counter()
+                        self.logs["delta_timestamp_s"] = now - self._last_time
+                        self.logs["timestamp_utc"] = capture_timestamp_utc()
+                        self._last_time = now
+                        self._frame = img
+
+        self._loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_until_complete(receive())
+
+    # public API -------------------------------------------------------
+    def connect(self) -> None:
+        if self.is_connected:
+            raise RobotDeviceAlreadyConnectedError("GatewayCamera is already connected.")
+        if self.mock:
+            self._frame = np.zeros((self.height, self.width, 3), dtype=np.uint8)
+            self.is_connected = True
+            return
+
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+        # wait a tiny bit for connection establishment
+        time.sleep(0.1)
+        self.is_connected = True
+
+    def read(self) -> np.ndarray:
+        if not self.is_connected:
+            raise RobotDeviceNotConnectedError("GatewayCamera is not connected.")
+        while self._frame is None:
+            time.sleep(0.01)
+        return self._frame
+
+    def async_read(self) -> np.ndarray:
+        if not self.is_connected:
+            raise RobotDeviceNotConnectedError("GatewayCamera is not connected.")
+        return self._frame
+
+    def disconnect(self) -> None:
+        if not self.is_connected:
+            raise RobotDeviceNotConnectedError("GatewayCamera is not connected.")
+        if self.mock:
+            self.is_connected = False
+            self._frame = None
+            return
+        if self._loop and self._ws:
+            asyncio.run_coroutine_threadsafe(self._ws.close(), self._loop).result()
+            self._loop.call_soon_threadsafe(self._loop.stop)
+        if self._thread:
+            self._thread.join(timeout=1)
+        self._frame = None
+        self.is_connected = False
+
+    def __del__(self) -> None:
+        if getattr(self, "is_connected", False):
+            self.disconnect()

--- a/lerobot/common/robot_devices/cameras/utils.py
+++ b/lerobot/common/robot_devices/cameras/utils.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from lerobot.common.robot_devices.cameras.configs import (
     CameraConfig,
+    GatewayCameraConfig,
     IntelRealSenseCameraConfig,
     OpenCVCameraConfig,
 )
@@ -30,6 +31,10 @@ def make_cameras_from_configs(camera_configs: dict[str, CameraConfig]) -> list[C
             from lerobot.common.robot_devices.cameras.intelrealsense import IntelRealSenseCamera
 
             cameras[key] = IntelRealSenseCamera(cfg)
+        elif cfg.type == "gateway":
+            from lerobot.common.robot_devices.cameras.gateway import GatewayCamera
+
+            cameras[key] = GatewayCamera(cfg)
         else:
             raise ValueError(f"The motor type '{cfg.type}' is not valid.")
 
@@ -48,6 +53,12 @@ def make_camera(camera_type, **kwargs) -> Camera:
 
         config = IntelRealSenseCameraConfig(**kwargs)
         return IntelRealSenseCamera(config)
+
+    elif camera_type == "gateway":
+        from lerobot.common.robot_devices.cameras.gateway import GatewayCamera
+
+        config = GatewayCameraConfig(**kwargs)
+        return GatewayCamera(config)
 
     else:
         raise ValueError(f"The camera type '{camera_type}' is not valid.")

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -86,3 +86,18 @@ def test_gateway_bus_mock_mode():
     assert len(obs) == len(FEETECH_MOTORS)
     bus.disconnect()
     assert not bus.is_connected
+
+
+def test_gateway_camera_mock_mode():
+    from lerobot.common.robot_devices.cameras.gateway import GatewayCamera
+    from lerobot.common.robot_devices.cameras.configs import GatewayCameraConfig
+
+    cfg = GatewayCameraConfig(url="ws://localhost", mock=True)
+    cam = GatewayCamera(cfg)
+    assert not cam.is_connected
+    cam.connect()
+    assert cam.is_connected
+    img = cam.async_read()
+    assert img.shape[0] == cam.height
+    cam.disconnect()
+    assert not cam.is_connected

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -311,6 +311,10 @@ def make_camera(camera_type: str, **kwargs) -> Camera:
     elif camera_type == "intelrealsense":
         serial_number = kwargs.pop("serial_number", INTELREALSENSE_SERIAL_NUMBER)
         return make_camera_device(camera_type, serial_number=serial_number, **kwargs)
+
+    elif camera_type == "gateway":
+        url = kwargs.pop("url", "ws://localhost:8765")
+        return make_camera_device(camera_type, url=url, **kwargs)
     else:
         raise ValueError(f"The camera type '{camera_type}' is not valid.")
 


### PR DESCRIPTION
## Summary
- extend gateway service documentation to mention camera streaming
- allow camera gateway configuration and runtime streaming via `GatewayCamera`
- register new gateway camera type
- update test utilities and add unit test

## Testing
- `pytest tests/test_gateway.py::test_gateway_camera_mock_mode -q` *(fails: module 'torch' has no attribute 'Tensor')*

------
https://chatgpt.com/codex/tasks/task_b_683fb2183608832abe2208aedf290c13