### PR TITLE
Add remote-ready scaffolding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM nvidia/cuda:12.4.1-base-ubuntu22.04
+
+ARG PYTHON_VERSION=3.10
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH="/opt/venv/bin:$PATH"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python${PYTHON_VERSION} python${PYTHON_VERSION}-venv python${PYTHON_VERSION}-dev \
+        build-essential git curl && \
+    ln -s /usr/bin/python${PYTHON_VERSION} /usr/bin/python && \
+    python -m venv /opt/venv && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    echo "source /opt/venv/bin/activate" >> /root/.bashrc
+
+COPY . /app
+WORKDIR /app
+RUN pip install --upgrade pip && pip install .[test] && pip cache purge
+
+EXPOSE 8000
+HEALTHCHECK CMD curl -f http://localhost:8000/env || exit 1
+
+CMD uvicorn server.main:app --host 0.0.0.0 --port 8000

--- a/chrome_web_app/README.md
+++ b/chrome_web_app/README.md
@@ -1,0 +1,5 @@
+# Chrome Web App
+
+This folder is a placeholder for the browser interface. It would handle
+user authentication, dataset upload, starting training jobs and running
+inference using the REST/WS API provided by the server.

--- a/docs/api_openapi.yaml
+++ b/docs/api_openapi.yaml
@@ -1,0 +1,77 @@
+openapi: 3.1.0
+info:
+  title: LeRobot Remote API
+  version: 0.1.0
+paths:
+  /api/upload_calibration:
+    post:
+      summary: Upload calibration YAML
+      requestBody:
+        required: true
+        content:
+          application/x-yaml:
+            schema:
+              type: string
+      responses:
+        '200':
+          description: Calibration stored
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  calibration_id:
+                    type: string
+  /api/train:
+    post:
+      summary: Start training job
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                policy:
+                  type: string
+                dataset:
+                  type: string
+      responses:
+        '200':
+          description: Job started
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  job_id:
+                    type: string
+  /api/infer:
+    post:
+      summary: Run inference
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                observations:
+                  type: array
+                  items:
+                    type: number
+      responses:
+        '200':
+          description: Inference results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  actions:
+                    type: array
+                    items:
+                      type: number
+  /api/video:
+    websocket:
+      summary: Video stream

--- a/docs/runpod_deploy.md
+++ b/docs/runpod_deploy.md
@@ -1,0 +1,24 @@
+# Deploying LeRobot on RunPod
+
+This document gives a minimal example to run the cloud API on a GPU pod.
+
+## Build and push the Docker image
+```bash
+docker build -t <registry>/lerobot-runpod:latest .
+docker push <registry>/lerobot-runpod:latest
+```
+
+## RunPod template
+
+```yaml
+image: <registry>/lerobot-runpod:latest
+cmd: uvicorn server.main:app --host 0.0.0.0 --port 8000
+ports:
+  - containerPort: 8000
+    protocol: tcp
+env:
+  - name: LEROBOT_MODE
+    value: "cloud"
+```
+
+Deploy the template through the RunPod dashboard. The API will be available on the exposed port.

--- a/lerobot_core_cloud/__init__.py
+++ b/lerobot_core_cloud/__init__.py
@@ -1,0 +1,22 @@
+"""Core cloud utilities for LeRobot."""
+from __future__ import annotations
+
+from typing import Any, List
+
+
+def upload_calibration(data: bytes) -> str:
+    """Store calibration data and return an identifier."""
+    # In a real implementation this would persist to storage.
+    return "calib-001"
+
+
+def train(policy: str, dataset: str) -> dict:
+    """Start a training job for the given policy and dataset."""
+    # Placeholder training routine
+    return {"job_id": "job-001", "policy": policy, "dataset": dataset}
+
+
+def infer(observations: List[float] | None = None) -> List[float]:
+    """Run inference and return a list of actions."""
+    # Dummy inference returning zeros
+    return [0.0]

--- a/lerobot_core_cloud/api.py
+++ b/lerobot_core_cloud/api.py
@@ -1,0 +1,51 @@
+"""FastAPI server exposing the cloud API."""
+from __future__ import annotations
+
+from fastapi import FastAPI, File, UploadFile, WebSocket
+from pydantic import BaseModel
+
+from . import infer, train, upload_calibration
+
+app = FastAPI(title="LeRobot Remote API")
+
+
+@app.get("/env")
+async def read_env():
+    return {"mode": "cloud"}
+
+
+@app.post("/api/upload_calibration")
+async def api_upload_calibration(file: UploadFile = File(...)):
+    data = await file.read()
+    calibration_id = upload_calibration(data)
+    return {"calibration_id": calibration_id}
+
+
+class TrainRequest(BaseModel):
+    policy: str
+    dataset: str
+
+
+@app.post("/api/train")
+async def api_train(req: TrainRequest):
+    return train(req.policy, req.dataset)
+
+
+class InferRequest(BaseModel):
+    observations: list[float] | None = None
+
+
+@app.post("/api/infer")
+async def api_infer(req: InferRequest):
+    return {"actions": infer(req.observations)}
+
+
+@app.websocket("/api/video")
+async def api_video(ws: WebSocket):
+    await ws.accept()
+    try:
+        while True:
+            await ws.receive_bytes()
+            await ws.send_text("ack")
+    except Exception:
+        await ws.close()

--- a/lerobot_edge/__init__.py
+++ b/lerobot_edge/__init__.py
@@ -1,0 +1,7 @@
+"""Edge utilities exposing hardware access."""
+from __future__ import annotations
+
+
+def connect_arm(vid: int, pid: int) -> None:
+    """Placeholder for connecting to a physical robot arm."""
+    print(f"Connecting to arm VID={vid} PID={pid}")

--- a/lerobot_edge/cli.py
+++ b/lerobot_edge/cli.py
@@ -1,0 +1,25 @@
+"""Command line interface for the edge agent."""
+import argparse
+
+from . import connect_arm
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the LeRobot edge agent")
+    parser.add_argument("run", action="store_true")
+    parser.add_argument("--model-path", required=False)
+    parser.add_argument("--token", required=False)
+    args = parser.parse_args()
+
+    if args.run:
+        print("Starting edge agent")
+        if args.model_path:
+            print(f"Using model at {args.model_path}")
+        if args.token:
+            print("Token provided")
+        # Placeholder for hardware connection guidance
+        connect_arm(0, 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/lerobot_remote/__init__.py
+++ b/lerobot_remote/__init__.py
@@ -1,0 +1,15 @@
+"""Dynamic import helper based on ``LEROBOT_MODE``."""
+from __future__ import annotations
+
+import os
+
+mode = os.environ.get("LEROBOT_MODE", "cloud")
+
+if mode == "cloud":
+    from lerobot_core_cloud import *  # noqa: F401,F403
+elif mode == "edge":
+    from lerobot_edge import *  # noqa: F401,F403
+else:
+    raise ValueError(f"Invalid LEROBOT_MODE: {mode}")
+
+__all__ = ["mode"]

--- a/server/main.py
+++ b/server/main.py
@@ -1,0 +1,4 @@
+"""Entry point for the cloud API server."""
+from lerobot_core_cloud.api import app
+
+__all__ = ["app"]

--- a/tests/test_remote_mode.py
+++ b/tests/test_remote_mode.py
@@ -1,0 +1,18 @@
+import importlib
+import os
+
+import pytest
+
+
+@pytest.mark.cloud
+def test_cloud_mode(monkeypatch):
+    monkeypatch.setenv("LEROBOT_MODE", "cloud")
+    mod = importlib.import_module("lerobot_remote")
+    assert mod.mode == "cloud"
+
+
+@pytest.mark.edge
+def test_edge_mode(monkeypatch):
+    monkeypatch.setenv("LEROBOT_MODE", "edge")
+    mod = importlib.import_module("lerobot_remote")
+    assert mod.mode == "edge"

--- a/tests/test_server_import.py
+++ b/tests/test_server_import.py
@@ -1,0 +1,6 @@
+import importlib
+
+
+def test_server_app():
+    mod = importlib.import_module("server.main")
+    assert hasattr(mod, "app")


### PR DESCRIPTION
## Summary
- add Dockerfile for RunPod deployment
- sketch cloud and edge packages
- add dynamic module loader via `LEROBOT_MODE`
- implement simple FastAPI server
- document RunPod setup and API schema
- include minimal Chrome web app placeholder
- add tests for the new import logic

## Testing
- `pytest tests/test_remote_mode.py tests/test_server_import.py -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_684353f4e7f4832aa46753646148b599